### PR TITLE
Fix object key order validation rule

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -69,6 +69,6 @@ requireTemplateStrings: true
 safeContextKeyword: self
 validateIndentation: 2
 validateLineBreaks: LF
-validateOrderInObjectKeys: asc
+validateOrderInObjectKeys: asc-natural
 validateParameterSeparator: ", "
 validateQuoteMarks: "'"


### PR DESCRIPTION
With `asc`, the `INVALID_FIELD` in the following example would need to be at the bottom:

```bash
Object keys must be in ascending order at ./src/constants.js :
   499 |  INVALID_EXTENSION: '21035',
   500 |  INVALID_FIELD: '30000',
   501 |  INVALID_FIELD_SELECTED: '21027',
----------^
   502 |  INVALID_FIELDS_SPECIFIED_IN_REQUEST: '10600',
```

R=@ruiquelhas