### PR TITLE
Remove require padding before `finally`

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -46,7 +46,7 @@ requirePaddingNewLinesAfterBlocks: { allExcept: ['inCallExpressions', 'inNewExpr
 requirePaddingNewLinesAfterUseStrict: true
 requirePaddingNewLinesBeforeExport: true
 requirePaddingNewLinesBeforeLineComments: { allExcept: firstAfterCurly }
-requirePaddingNewlinesBeforeKeywords: [ case, do, finally, for, function, if, return, switch, try, typeof, void, while, with ]
+requirePaddingNewlinesBeforeKeywords: [ case, do, for, function, if, return, switch, try, typeof, void, while, with ]
 requireParenthesesAroundIIFE: true
 requireSemicolons: true
 requireShouldAssertionExecution: true


### PR DESCRIPTION
The `requirePaddingNewlinesBeforeKeywords` rule currently in use does not allow:

```js
try {
  ...
} catch (err) {
  ...
} finally {
  ...
}
```