### PR TITLE
Disable `disallowKeywordsInComments` rule

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -3,7 +3,7 @@ disallowDanglingUnderscores: true
 disallowEmptyBlocks: true
 disallowGeneratorsInDescribeFunctions: true
 disallowKeywords: [ with ]
-disallowKeywordsInComments: true
+disallowKeywordsInComments: false
 disallowKeywordsOnNewLine: [ catch, else, while ]
 disallowMixedSpacesAndTabs: true
 disallowMultipleLineBreaks: true


### PR DESCRIPTION
This change allows comments like `// TODO` and `//FIXME`.