### PR TITLE
Remove `validateIndentation` rule

### DIFF
--- a/src/presets/seegno.json
+++ b/src/presets/seegno.json
@@ -134,7 +134,6 @@
   "requireSqlTemplate": true,
   "requireTemplateStrings": true,
   "safeContextKeyword": "self",
-  "validateIndentation": 2,
   "validateLineBreaks": "LF",
   "validateOrderInObjectKeys": "asc-natural",
   "validateParameterSeparator": ", ",


### PR DESCRIPTION
Removes `validateIndentation` since it doesn't support ES7 code.