### PR TITLE
Remove `validateOrderInObjectKeys` rule

### DIFF
--- a/src/presets/seegno.json
+++ b/src/presets/seegno.json
@@ -135,7 +135,6 @@
   "safeContextKeyword": "self",
   "validateIndentation": 2,
   "validateLineBreaks": "LF",
-  "validateOrderInObjectKeys": "asc-natural",
   "validateParameterSeparator": ", ",
   "validateQuoteMarks": "'"
 }


### PR DESCRIPTION
This rule is being deprecated in favor of eslint `sorting/sort-object-props`.

_Resolves https://github.com/seegno/jscs-config-seegno/issues/31._
